### PR TITLE
Simple fix for VRCUK v1.4.1 change

### DIFF
--- a/Entries/PlayerEntry.cs
+++ b/Entries/PlayerEntry.cs
@@ -19,6 +19,7 @@ using VRChatUtilityKit.Ui;
 using VRChatUtilityKit.Utilities;
 using VRCSDK2.Validation.Performance;
 using VRC.DataModel;
+using Il2CppSystem.Collections;
 
 using Player = VRC.Player;
 
@@ -256,10 +257,14 @@ namespace PlayerList.Entries
         }
 
         // So apparently if you don't want to name an enum directly in a harmony patch you have to use int as the type... good to know
-        private static void OnSetupFlagsReceived(VRCPlayer vrcPlayer, int SetupFlagType)
+        private static void OnSetupFlagsReceived(VRCPlayer vrcPlayer, Hashtable SetupFlagType)
         {
-            if (SetupFlagType == 64)
-                EntryManager.idToEntryTable[vrcPlayer.prop_Player_0.prop_APIUser_0.id].playerEntry.GetPlayerColor();
+            try
+            {   //Will occasionally error at EntryManager.idToEntryTable[vrcPlayer.prop_Player_0.prop_APIUser_0.id]
+                if (SetupFlagType.ContainsKey("showSocialRank"))
+                    EntryManager.idToEntryTable[vrcPlayer.prop_Player_0.prop_APIUser_0.id].playerEntry.GetPlayerColor();
+            }
+            catch { }
         }
         public static void UpdateEntry(PlayerNet playerNet, PlayerEntry entry, bool bypassActive = false)
         {


### PR DESCRIPTION
VRCUK has a breaking change, OnSetupFlagsReceived has been fixed and it's int replaced with a Hashable
Playerlist needs 1 line changed where it compares that to 64, this is included in the pull request. 
It is ugly, and has a dumb try catch, but works?

This is more just to let you know. VRCUK v1.4.1 will be published along with a new deobf map soonish? (Likely along with ML0.5.4)  

Also, enable Issues on this repo so I can just toss this info in an issue in the future :P 