### PR TITLE
Added check for OnSetupFlagsReceived

### DIFF
--- a/Entries/PlayerEntry.cs
+++ b/Entries/PlayerEntry.cs
@@ -257,16 +257,9 @@ namespace PlayerList.Entries
         // So apparently if you don't want to name an enum directly in a harmony patch you have to use int as the type... good to know
         private static void OnSetupFlagsReceived(VRCPlayer vrcPlayer, Hashtable SetupFlagType)
         {
-            if (SetupFlagType.ContainsKey("showSocialRank") && SetupFlagType["showSocialRank"].ToString() == "True")
+            if (EntryManager.idToEntryTable.ContainsKey(vrcPlayer.prop_Player_0.prop_APIUser_0.id) && SetupFlagType.ContainsKey("showSocialRank") && SetupFlagType["showSocialRank"].ToString() == "True")
             {
-                try
-                {
-                    EntryManager.idToEntryTable[vrcPlayer.prop_Player_0.prop_APIUser_0.id]?.playerEntry?.GetPlayerColor();
-                }
-                catch
-                {
-                    PlayerListMod.Instance.LoggerInstance.Warning("Couldn't get player entry in OnSetupFlagsReceived");
-                }
+                EntryManager.idToEntryTable[vrcPlayer.prop_Player_0.prop_APIUser_0.id]?.playerEntry?.GetPlayerColor();
             }
         }
         public static void UpdateEntry(PlayerNet playerNet, PlayerEntry entry, bool bypassActive = false)


### PR DESCRIPTION
Check if usr id exists in table before attempting to get player colors. Reduce warning spam.

This is to resolve an error that occurs when it attempts to GetPlayerColor when you or a player joins a world before the player is added to the EntryTable.

Behavior seems to work as intended when I threw in debug messages temporarily.